### PR TITLE
Update tests and fallback DbContext

### DIFF
--- a/AirTicketSalesManagement/AirTicketSalesManagement.csproj
+++ b/AirTicketSalesManagement/AirTicketSalesManagement.csproj
@@ -41,8 +41,9 @@
 		<PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+                <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+                <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/AirTicketSalesManagement/Data/AirTicketDbContext.cs
+++ b/AirTicketSalesManagement/Data/AirTicketDbContext.cs
@@ -54,8 +54,30 @@ public partial class AirTicketDbContext : DbContext
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        var connectionString = GetConnectionString();
-        optionsBuilder.UseSqlServer(connectionString);
+        if (optionsBuilder.IsConfigured)
+        {
+            return;
+        }
+
+        string? connectionString = null;
+        try
+        {
+            connectionString = GetConnectionString();
+        }
+        catch (FileNotFoundException)
+        {
+            // Swallow the exception and fall back to an in-memory database
+        }
+
+        if (!string.IsNullOrWhiteSpace(connectionString))
+        {
+            optionsBuilder.UseSqlServer(connectionString);
+        }
+        else
+        {
+            // Default to an in-memory database to allow running without a configuration file
+            optionsBuilder.UseInMemoryDatabase("AirTicketInMemoryDb");
+        }
     }
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/AirTicketSalesManagementTests/AirTicketSalesManagementTests.csproj
+++ b/AirTicketSalesManagementTests/AirTicketSalesManagementTests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="MSTest.Sdk/3.6.1">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseVSTest>true</UseVSTest>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # AirTicketSalesManagement
+
+This repository contains a WPF application and a set of MSTest unit tests.
+
+## Database configuration
+
+`AirTicketDbContext` normally reads the database connection string from `appsettings.json`. If that file is missing, the context now falls back to an in-memory database so tests can run without a SQL Server instance. To use a real database, place `appsettings.json` next to `AirTicketSalesManagement.csproj` with a `DefaultConnection` entry.
+
+## Running the tests
+
+Ensure that the .NET SDK 8.0 or later is installed and then run:
+
+```bash
+cd AirTicketSalesManagementTests
+ dotnet test
+```
+
+The tests target `net8.0-windows`, so they require Windows or a compatible environment.


### PR DESCRIPTION
## Summary
- make tests target the same framework as the WPF app
- allow `AirTicketDbContext` to fall back to an in-memory DB when `appsettings.json` isn't present
- add EF Core InMemory reference
- document running tests

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867bbe3cf3c832fa2fe5d861d05e4ae