### PR TITLE
Update test project for WPF

### DIFF
--- a/AirTicketSalesManagementTests/AirTicketSalesManagementTests.csproj
+++ b/AirTicketSalesManagementTests/AirTicketSalesManagementTests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="MSTest.Sdk/3.6.1">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UseVSTest>true</UseVSTest>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- set AirTicketSalesManagementTests to target `net8.0-windows`
- enable WPF usage in the test project

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686802d27ad4832f9f2b4ee4c365099d